### PR TITLE
new cli argument. fix download

### DIFF
--- a/src/statement_dl/__init__.py
+++ b/src/statement_dl/__init__.py
@@ -65,6 +65,11 @@ def main():
         " password are set",
     )
     download_parent_parser.add_argument(
+        "--sub-dirs",
+        action="store_true",
+        help="Store pdf files in separate sub directories",
+    )
+    download_parent_parser.add_argument(
         "-a",
         "--all-files",
         action="store_true",

--- a/src/statement_dl/flatex.py
+++ b/src/statement_dl/flatex.py
@@ -171,8 +171,8 @@ def _download_pdfs(
     dest: Path,
     download_path: Path,
     all_files: bool,
-    sub_dirs: bool,
     keep_filenames: bool,
+    sub_dirs: bool,
     tld: str,
 ) -> None:
     _set_download_filter(driver, from_date, to_date, all_files)

--- a/src/statement_dl/flatex.py
+++ b/src/statement_dl/flatex.py
@@ -31,7 +31,7 @@ onclick = """
 
 
 onfinished = """
-    DownloadDocumentBrowserBehaviorsClick.finished = function(a, b) {
+    DocumentViewer.display = function(a, b) {
        console.log(a);
        window.pdf_download_url = a;
     };
@@ -226,7 +226,9 @@ def _set_download_filter(
     date_to_elem = driver.find_element_by_xpath(
         '//input[contains(@id, "dateRangeComponent_endDate")]'
     )
+    time.sleep(1)
     _enter_date(driver, date_from_elem, from_date)
+    time.sleep(1)
     _enter_date(driver, date_to_elem, to_date)
 
     try:


### PR DESCRIPTION
Hi. I fixed the issue with the index and added an CLI option to store the PDFs in separate sub directories.
However, the download does not work anymore, because Flatex might have changed a javascript element.

This does not work anymore: 
```
onfinished = """
    DownloadDocumentBrowserBehaviorsClick.finished = function(a, b) {
       console.log(a);
       window.pdf_download_url = a;
    };
"""
```

DownloadDocumentBrowserBehaviorsClick cannot be found.

Unfortunately, I cannot figure out how to fix this problem.